### PR TITLE
🐞zalenium upstream chart is added🐞

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -264,7 +264,7 @@ applications:
     ignore_differences: *crw_ignore_differences
   - name: zalenium
     enabled: true
-    source: https://github.com/ckavili/zalenium.git
+    source: https://github.com/zalando/zalenium.git
     source_path: charts/zalenium
     source_ref: "master"
     sync_policy:


### PR DESCRIPTION
Zalenium upstream chart has updated to comply with Openshift so I updated the `values-tooling.yaml`
The reason of `source_ref: "master"` is that the latest release doesn't contain this update and they stopped to release new charts like 18 days ago 🤦🏻‍♀️ https://github.com/zalando/zalenium/releases/tag/3.141.59z