### PR TITLE
Fix/jenkins secret

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -225,9 +225,9 @@ applications:
     ignore_differences: *nexus_ignore_differences
   - name: jenkins
     enabled: true
-    source: https://github.com/eformat/charts.git
+    source: https://github.com/rht-labs/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "fix/jenkins-secret"
+    source_ref: "jenkins-0.0.9"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -225,9 +225,9 @@ applications:
     ignore_differences: *nexus_ignore_differences
   - name: jenkins
     enabled: true
-    source: https://github.com/eformat/helm-charts.git
+    source: https://github.com/eformat/charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-0.0.10"
+    source_ref: "fix/jenkins-secret"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -7,7 +7,7 @@ destination: &ci_cd_ns labs-ci-cd
 jenkins_values: &jenkins_values
   persistence: false
   source_secret:
-    name: gitlab-auth
+    name: git-auth
     username: idm-sa
     password: thisisdefinitelynotmypassword
 

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -225,9 +225,9 @@ applications:
     ignore_differences: *nexus_ignore_differences
   - name: jenkins
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/eformat/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-0.0.9"
+    source_ref: "jenkins-0.0.10"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns


### PR DESCRIPTION
this is the anchor, sub chart issue again - i.e. we anchors are always local to the yaml file based on the yaml spec so cannot be overridden.

because the jenkins subchart uses git-auth anchor for the BC secret name, we need to override the secret with the same name i.e. 'git-auth'

else jenkins build never starts.

the jenkins chart may need to reconsider secret injection .. this works for now i.e. username and password are overridden as expected, but secret name has to be identical
