### PR TITLE
🥕 change argocd clustername 🥕

### DIFF
--- a/bootstrap/values-bootstrap.yaml
+++ b/bootstrap/values-bootstrap.yaml
@@ -54,7 +54,7 @@ bootstrap-project:
 
 argocd:
   enabled: true
-  name: argocd
+  name: labs-argocd
   namespace: *ci_cd
   version: v1.5.2
   instancelabel: redhat.com/ubiquitous-journey


### PR DESCRIPTION
when using just 'argocd' for the server name, i get a weird behavior form the latest version 1.5.2 and operator 0.6 where the server continually restarts every 60s

argocd-server-695cc445db-5wx4m                   1/1     Running             0          60s
argocd-server-784f74f89-npdcn                    0/1     ContainerCreating   0          0s

this is likely a bug in the operator (i see there is a newer 0.7 version) but not in community chart yet.

setting the name differently seems to be  workaround for now