### PR TITLE
🛫 remove crw CSV version, let OLM decide  🛫

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -255,9 +255,9 @@ applications:
   - name: crw
     enabled: true
     destination: crw
-    source: https://github.com/rht-labs/refactored-adventure
+    source: https://github.com/eformat/refactored-adventure
     source_path: crw/base
-    source_ref: master
+    source_ref: fix/crw-version
     sync_policy:
       *sync_policy_no_selfheal
     no_helm: true


### PR DESCRIPTION
there is no need to set CSV version for the operator (unless we want to explicitly do so) for crw

this will allow the OLM to resolve the operator version from the CatalogSource - currently 2.1.0

better supported across openshift olm that may not be updated automatically and saves us having to explicitly set the version each time (which has its upsides and downsides)