### PR TITLE
Add Hashicorp Vault

### DIFF
--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -187,6 +187,31 @@ owncloud_values: &owncloud_values
     enabled: true
   hostname: owncloud.apps.hivec.sandbox1559.opentlc.com
 
+#######################
+# Vault Custom Values #
+#######################
+vault_values: &vault_values
+  global:
+    tlsDisable: false
+  injector:
+    enabled: false
+  openshift: true
+  server:
+    route:
+      host: '""'
+    standalone:
+      config: |
+        ui = true
+        listener "tcp" {
+          address = "[::]:8200"
+          cluster_address = "[::]:8201"
+          tls_cert_file = "/var/run/secrets/kubernetes.io/certs/tls.crt"
+          tls_key_file = "/var/run/secrets/kubernetes.io/certs/tls.key"
+        }
+        storage "file" {
+          path = "/vault/data"
+        }
+
 ##############
 # 🐙 Argo Ignore Differences
 #############
@@ -247,6 +272,14 @@ owncloud_ignore_differences: &owncloud_ignore_differences
     jsonPointers:
     - /spec/template/spec/containers/0/image
     - /spec/triggers/0/imageChangeParams/lastTriggeredImage
+
+vault_ignore_differences: &vault_ignore_differences
+  ignoreDifferences:
+  - group: route.openshift.io
+    kind: Route
+    jsonPointers:
+    - /status/ingress
+    - /spec/host
 
 ##############
 # 🐙 Argo Sync Policy
@@ -397,3 +430,14 @@ applications:
     ignore_differences: *owncloud_ignore_differences
     values:
       *owncloud_values
+  - name: vault
+    enabled: true
+    source: https://github.com/radudd/vault-helm.git
+    source_path: .
+    source_ref: openshift
+    destination: *ci_cd_ns
+    sync_policy:
+      *sync_policy_true
+    ignore_differences: *vault_ignore_differences
+    values:
+      *vault_values


### PR DESCRIPTION
Let's you spin up Hashicorp Vault, fixes #18 
The remote Helm chart is currently submitted as an upstream PR [hashicorp/vault-helm: #289](hashicorp/vault-helm/pull/289) so once that gets merged we can switch to upstream vault-helm.