### PR TITLE
🦆 nexus ubi chart from channel 🦆

### DIFF
--- a/ubiquitous-journey/templates/argoapplicationdeploy.yaml
+++ b/ubiquitous-journey/templates/argoapplicationdeploy.yaml
@@ -26,9 +26,14 @@ spec:
 {{- toYaml $app.values | nindent 8 }}
 {{- end }}
 {{- end }}
+    {{- if $app.source_path }}
     path: {{ $app.source_path }}
+    {{- end }}
     repoURL: {{ $app.source }}
     targetRevision: {{ $app.source_ref | default "master" }}
+    {{- if $app.chart_name }}
+    chart: {{ $app.chart_name }}
+    {{- end}}
 {{- if $app.sync_policy }}
 {{- toYaml $app.sync_policy | nindent 2 }}
 {{- end }}

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -39,81 +39,6 @@ pact_broker_values: &pact_broker_values
       pactBrokerBasicAuthPassword: thisisdefinitelynotmypassword
 
 ##############
-# 🛎 Sonatype Nexus Custom Values
-#############
-nexus_values: &nexus_values
-  nexus:
-    imageName: sonatype/nexus3
-    imageTag: 3.19.1
-    service:
-      type: ClusterIP
-    podAnnotations: {}
-    securityContextEnabled: false
-
-  route:
-    enabled: true
-    name: nexus
-    portName: nexus-service
-    path: null
-
-  nexusProxy:
-    enabled: false
-
-  persistence:
-    storageSize: 5Gi
-
-  serviceAccount:
-    name: nexus
-    annotations: {}
-
-  additionalConfigMaps:
-    - name: maven-central
-      labels:
-        nexus-type: repository
-      data:
-        recipe: 'MavenProxy'
-        remoteUrl: 'https://repo.maven.apache.org/maven2/'
-        blobStoreName: 'default'
-        strictContentTypeValidation: 'true'
-        versionPolicy: 'RELEASE'
-        layoutPolicy: 'STRICT'
-    - name: labs-static
-      labels:
-        nexus-type: repository
-      data:
-        recipe: 'RawHosted'
-        blobStoreName: 'default'
-
-  deployment:
-    annotations: {}
-    initContainers:
-      - name: k8s-plugin-puller
-        image: curlimages/curl:latest
-        imagePullPolicy: Always
-        command: ['sh','-c']
-        args: ['curl -L -o /k8s-plugin/nexus-openshift-plugin.jar https://github.com/sonatype-nexus-community/nexus-kubernetes-openshift/releases/download/v0.2.8/nexus-openshift-plugin-0.2.8.jar']
-        volumeMounts:
-          - name: k8s-plugin
-            mountPath: /k8s-plugin
-    additionalVolumes:
-      - name: k8s-plugin
-        emptyDir: {}
-    additionalVolumeMounts:
-      - mountPath: /opt/sonatype/nexus/deploy/nexus-openshift-plugin.jar
-        name: k8s-plugin
-        subPath: nexus-openshift-plugin.jar
-
-  service:
-    enabled: true
-    name: nexus-service
-    labels: {}
-    annotations: {}
-    portName: nexus-service
-    port: 8081
-    targetPort: 8081
-    ports: []
-
-##############
 # 🛎 Zalenium Custom Values
 #############
 ## TODO: Update source URL as upstream when ArgoCD version is greater 1.5.0 or above
@@ -306,14 +231,13 @@ sync_policy_no_selfheal: &sync_policy_no_selfheal
 applications:
   - name: nexus
     enabled: true
-    source: https://github.com/Oteemo/charts.git
-    source_path: charts/sonatype-nexus
-    source_ref: "sonatype-nexus-2.1.0"
+    source: https://rht-labs.github.io/helm-charts/
+    chart_name: sonatype-nexus
+    source_path: ""
+    source_ref: "0.0.1"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns
-    values:
-      *nexus_values
     ignore_differences: *nexus_ignore_differences
   - name: jenkins
     enabled: true


### PR DESCRIPTION
replace the use of nexus ootemo chert with rht-labs chart

this uses the official redhat connect partner nexus image based on ubi which is latest and support helm repositories

https://github.com/rht-labs/helm-charts/blob/master/charts/sonatype-nexus/values.yaml#L34