### PR TITLE
Github Action: Charts linting only

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Lint Charts
+
+on:
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: lint --chart-dirs . --all
+          config: ct.yaml


### PR DESCRIPTION
Adds GH action to check chart linting only. No helm chart installation yet.

Related with https://github.com/rht-labs/ubiquitous-journey/pull/96.

Leaving for further discussion where and how we ant to test helm charts installations.