### PR TITLE
🐋 use latest argocd operator version 0.0.12 🐋

### DIFF
--- a/bootstrap-master/values-bootstrap.yaml
+++ b/bootstrap-master/values-bootstrap.yaml
@@ -25,7 +25,7 @@ argocd-operator:
   # operator manages upgrades etc
   version: v1.6.1
   operator:
-    version: argocd-operator.v0.0.11
+    version: argocd-operator.v0.0.12
     channel: alpha
     name: argocd-operator
 

--- a/bootstrap/values-bootstrap.yaml
+++ b/bootstrap/values-bootstrap.yaml
@@ -50,7 +50,7 @@ argocd-operator:
   # operator manages upgrades etc
   version: v1.6.1
   operator:
-    version: argocd-operator.v0.0.11
+    version: argocd-operator.v0.0.12
     channel: alpha
     name: argocd-operator
 


### PR DESCRIPTION
bump to 0.0.12