### PR TITLE
🐈‍ switch to redhat-cop, update latest argocd🐈‍

### DIFF
--- a/bootstrap-master/Chart.yaml
+++ b/bootstrap-master/Chart.yaml
@@ -8,8 +8,8 @@ version: 0.0.1
 appVersion: 0.0.1
 dependencies:
   - name: bootstrap-project
-    version: "0.0.6"
-    repository: https://rht-labs.github.io/helm-charts
+    version: "0.0.7"
+    repository: https://redhat-cop.github.io/helm-charts
   - name: argocd-operator
-    version: "0.0.10"
-    repository: https://rht-labs.github.io/helm-charts
+    version: "0.0.16"
+    repository: https://redhat-cop.github.io/helm-charts

--- a/bootstrap-master/values-bootstrap.yaml
+++ b/bootstrap-master/values-bootstrap.yaml
@@ -23,7 +23,7 @@ argocd-operator:
   instancelabel: rht-labs.com/master-argocd
   
   # operator manages upgrades etc
-  version: v1.6.1
+  version: v1.6.2
   operator:
     version: argocd-operator.v0.0.12
     channel: alpha
@@ -32,4 +32,4 @@ argocd-operator:
   metrics:
     enabled: true
     prometheus:
-      version: prometheusoperator.0.32.0
+      version: prometheusoperator.0.37.0

--- a/bootstrap/Chart.yaml
+++ b/bootstrap/Chart.yaml
@@ -8,11 +8,11 @@ version: 0.0.1
 appVersion: 0.0.1
 dependencies:
   - name: bootstrap-project
-    version: "0.0.6"
-    repository: https://rht-labs.github.io/helm-charts
+    version: "0.0.7"
+    repository: https://redhat-cop.github.io/helm-charts
   - name: argocd-operator
-    version: "0.0.14"
-    repository: https://rht-labs.github.io/helm-charts
+    version: "0.0.16"
+    repository: https://redhat-cop.github.io/helm-charts
   - name: sealed-secrets
     version: "1.10.2"
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/bootstrap/values-bootstrap.yaml
+++ b/bootstrap/values-bootstrap.yaml
@@ -48,7 +48,7 @@ argocd-operator:
   instancelabel: rht-labs.com/uj
   
   # operator manages upgrades etc
-  version: v1.6.1
+  version: v1.6.2
   operator:
     version: argocd-operator.v0.0.12
     channel: alpha
@@ -57,7 +57,7 @@ argocd-operator:
   metrics:
     enabled: true
     prometheus:
-      version: prometheusoperator.0.32.0
+      version: prometheusoperator.0.37.0
 
   # argocd rbac only in listed namespaces
   namespaceRoleBinding:

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -231,19 +231,19 @@ sync_policy_no_selfheal: &sync_policy_no_selfheal
 applications:
   - name: nexus
     enabled: true
-    source: https://rht-labs.github.io/helm-charts/
+    source: https://redhat-cop.github.io/helm-charts
     chart_name: sonatype-nexus
     source_path: ""
-    source_ref: "0.0.1"
+    source_ref: "0.0.4"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns
     ignore_differences: *nexus_ignore_differences
   - name: jenkins
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/jenkins
-    source_ref: "jenkins-0.0.16"
+    source_ref: "jenkins-0.0.19"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns
@@ -252,9 +252,9 @@ applications:
     ignore_differences: *jenkins_ignore_differences
   - name: pact-broker
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/pact-broker
-    source_ref: "pact-broker-0.0.2"
+    source_ref: "pact-broker-0.0.3"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns
@@ -262,9 +262,9 @@ applications:
       *pact_broker_values
   - name: sonarqube
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/sonarqube
-    source_ref: "sonarqube-0.0.4"
+    source_ref: "sonarqube-0.0.6"
     sync_policy:
       *sync_policy_true
     destination: *ci_cd_ns
@@ -328,27 +328,27 @@ applications:
       *mattermost_values
   - name: etherpad
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/etherpad
     destination: *ci_cd_ns
-    source_ref: "etherpad-0.0.1"
+    source_ref: "etherpad-0.0.2"
     sync_policy:
       *sync_policy_true
   - name: dev-ex-dashboard
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/dev-ex-dashboard
     destination: *ci_cd_ns
-    source_ref: "dev-ex-dashboard-0.0.1"
+    source_ref: "dev-ex-dashboard-0.0.2"
     sync_policy:
       *sync_policy_no_selfheal
     ignore_differences: *dev-ex-dashboard_ignore_differences
   - name: owncloud
     enabled: true
-    source: https://github.com/rht-labs/helm-charts.git
+    source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/owncloud
     destination: *ci_cd_ns
-    source_ref: "owncloud-0.0.1"
+    source_ref: "owncloud-0.0.2"
     sync_policy:
       *sync_policy_true
     ignore_differences: *owncloud_ignore_differences


### PR DESCRIPTION
update defaults to use latest argocd, as well as re-point values to use redhat-cop helm chart repo