### PR TITLE
Switch vault to upstream chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ There are three main components (one in each folder) to this repository. Each pa
 - PactBroker - Deploy PactBroker for Contract Testing. See the [Pact Broker Chart](https://github.com/rht-labs/helm-charts/tree/master/charts/pact-broker) for more info.
 - CodeReadyWorkspaces - Deploy Red Hat CodeReadyWorkspaces for an IDE hosted on OpenShift. See the [CRW Kustomize](https://github.com/rht-labs/refactored-adventure) for more info.
 - Zalenium - Deploy Zalenium for Selenium Grid Testing on Kubernetes. See the [Zalenium Chart](https://github.com/ckavili/zalenium) for more info.
-- Ehterpad - Deploy Etherpad Lite for a real-time collaborative text editor. See [Etherpad Lite](https://github.com/ether/etherpad-lite) for more info.
+- Etherpad - Deploy Etherpad Lite for a real-time collaborative text editor. See [Etherpad Lite](https://github.com/ether/etherpad-lite) for more info.
 - Mattermost - Deploy Mattermost Team Edition for team collaboration and messaging See the [Mattermost Chart](https://github.com/mattermost/mattermost-helm) for more info.
+- Vault - Deploy Vault to securely store and access your secrets. See the [Vault Chart](https://github.com/hashicorp/vault-helm) for more info.
 
 ## What it's not...🤷🏻‍♀️
 

--- a/ubiquitous-journey/Chart.yaml
+++ b/ubiquitous-journey/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for ubiquitous-journey
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
-version: 0.0.1
+version: 0.0.2
 
-# This is the version number of the application being deployed. This version number should be
-appVersion: 0.0.1
+# This is the version number of the application being deployed. This version number should be incremented each time you make changes
+appVersion: 0.0.2

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -118,20 +118,27 @@ owncloud_values: &owncloud_values
 vault_values: &vault_values
   global:
     tlsDisable: false
+    openshift: true
   injector:
     enabled: false
-  openshift: true
-  server:
     route:
+      enabled: true
       host: '""'
+  server:
+    service:
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: vault-tls
+    extraVolumes:
+      - type: secret
+        name: vault-tls
     standalone:
       config: |
         ui = true
         listener "tcp" {
           address = "[::]:8200"
           cluster_address = "[::]:8201"
-          tls_cert_file = "/var/run/secrets/kubernetes.io/certs/tls.crt"
-          tls_key_file = "/var/run/secrets/kubernetes.io/certs/tls.key"
+          tls_cert_file = "/vault/userconfig/vault-tls/tls.crt"
+          tls_key_file  = "/vault/userconfig/vault-tls/tls.key"
         }
         storage "file" {
           path = "/vault/data"
@@ -356,9 +363,9 @@ applications:
       *owncloud_values
   - name: vault
     enabled: true
-    source: https://github.com/radudd/vault-helm.git
+    source: https://github.com/hashicorp/vault-helm.git
     source_path: .
-    source_ref: openshift
+    source_ref: "v0.7.0"   
     destination: *ci_cd_ns
     sync_policy:
       *sync_policy_true


### PR DESCRIPTION
Resolves https://github.com/rht-labs/ubiquitous-journey/issues/148

This PR will point back to the upstream `vault-helm` at version `0.0.7` chart which now has Openshift support.

There was a slight change to where the `openshift: true` variable lives now so I moved that under the `global` key.

I have also added Openshift-generated serving certs which mostly resolve tls errors once the app has started, however please note you will still need the `-tls-skip-verify` flag to initialize vault since these certs do not include the 127.0.0.1 IP SAN:

```bash
/ $ vault operator init -tls-skip-verify
Unseal Key 1: ************************************
Unseal Key 2: ************************************
Unseal Key 3: ************************************
Unseal Key 4: ************************************
Unseal Key 5: ************************************

Initial Root Token: ************************************

...
```
And once the vault in unsealed you will see everything go green in Argo with UJ and Vault :unicorn: 

```bash
/ $ vault operator unseal -tls-skip-verify
```