### PR TITLE
🏙 network policy chart added 🏙

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are three main components (one in each folder) to this repository. Each pa
   - `labs-ci-cd` to house CI/CD tools such as `Jenkins` and `Nexus` etc
   - `labs-dev`,  `labs-test` & `labs-staging` as target namespaces for deploying built artifacts
   - `labs-pm` to house additional tools to help with project management such as `OwnCloud`, `Wekan` and `Mattermost`
-  - `labs-cluster-ops` to house cron tasks and other jobs for pruning images and maintaining a healthy platform.
+  - `labs-cluster-ops` to house cron tasks and other jobs for pruning images, network policies and maintaining a healthy platform.
 - ArgoCD - Deploys an OpenShift auth enabled Dex Server along with the Operator version of ArgoCD.
 - SealedSecrets - Encrypt your Secret into a [SealedSecret](https://github.com/bitnami-labs/sealed-secrets), which is safe to store - even to a public repository. 
 - Jenkins - Create new custom Jenkins instance along with all the CoP build agents. See the [Jenkins Chart](https://github.com/redhat-cop/helm-charts/tree/master/charts/jenkins) for more info.
@@ -135,6 +135,7 @@ argocd app create uj-day2ops \
     --path "ubiquitous-journey" --values "values-day2ops.yaml"
 argocd app sync uj-day2ops
 ```
+_The [network policy chart](https://github.com/redhat-cop/helm-charts/tree/master/charts/network-policy) is namespace-scoped and is needed to be applied for each namespace seperately._
 
 
 ##### (B) Deploy using helm ...

--- a/ubiquitous-journey/values-day2ops.yaml
+++ b/ubiquitous-journey/values-day2ops.yaml
@@ -50,3 +50,12 @@ applications:
     values:
       namespace: *ops_ns
       prune_type: deployments
+  # Network Policies for Emulating Multitenancy
+  - name: network-policy
+    enabled: true
+    source: https://github.com/redhat-cop/helm-charts.git
+    source_path: charts/network-policy
+    sync_policy: *sync_policy_true
+    destination: *ops_ns
+    source_ref: "networkpolicy-1.0.0"
+

--- a/ubiquitous-journey/values-day2ops.yaml
+++ b/ubiquitous-journey/values-day2ops.yaml
@@ -52,7 +52,7 @@ applications:
       prune_type: deployments
   # Network Policies for Emulating Multitenancy
   - name: network-policy
-    enabled: true
+    enabled: false
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/network-policy
     sync_policy: *sync_policy_true


### PR DESCRIPTION
Network policy chart is added to day2ops. `labs-cluster-ops` namespace is selected as an example cause this should be in day2ops values file but it'd also make sense to add into `example-deployment` so I can change to what you think it's best :)

cc @rh-jpoole