### PR TITLE
🐃 chart versions bumped 🐃

### DIFF
--- a/bootstrap-master/Chart.yaml
+++ b/bootstrap-master/Chart.yaml
@@ -11,5 +11,5 @@ dependencies:
     version: "0.0.9"
     repository: https://redhat-cop.github.io/helm-charts
   - name: argocd-operator
-    version: "1.1.10"
+    version: "1.1.14"
     repository: https://redhat-cop.github.io/helm-charts

--- a/bootstrap-master/values-bootstrap.yaml
+++ b/bootstrap-master/values-bootstrap.yaml
@@ -35,7 +35,7 @@ argocd-operator:
 
   # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
   argocd_cr:
-    version: v2.0.5
+    version: v2.1.5
     accounts:
       accounts.admin: login, apiKey
     applicationInstanceLabelKey: rht-labs.com/uj

--- a/bootstrap/Chart.yaml
+++ b/bootstrap/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: "0.0.9"
     repository: https://redhat-cop.github.io/helm-charts
   - name: argocd-operator
-    version: "1.1.10"
+    version: "1.1.14"
     repository: https://redhat-cop.github.io/helm-charts
   - name: sealed-secrets
     version: "1.16.1"

--- a/bootstrap/values-bootstrap.yaml
+++ b/bootstrap/values-bootstrap.yaml
@@ -72,7 +72,7 @@ argocd-operator:
 
   # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
   argocd_cr:
-    version: v2.0.5
+    version: v2.1.5
     accounts:
       accounts.admin: login, apiKey
     applicationInstanceLabelKey: rht-labs.com/uj

--- a/ubiquitous-journey/values-extratooling.yaml
+++ b/ubiquitous-journey/values-extratooling.yaml
@@ -63,7 +63,7 @@ applications:
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/etherpad
     destination: *pm_ns
-    source_ref: "etherpad-0.0.2"
+    source_ref: "etherpad-0.0.7"
     sync_policy: *sync_policy_true
   # Dev-Ex Dashboard
   - name: dev-ex-dashboard

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -31,7 +31,7 @@ applications:
     source: https://redhat-cop.github.io/helm-charts
     chart_name: sonatype-nexus
     source_path: ""
-    source_ref: "0.0.5"
+    source_ref: "1.1.1"
     sync_policy: *sync_policy_true
     destination: *ci_cd_ns
     values:
@@ -102,7 +102,7 @@ applications:
     enabled: true
     source: https://github.com/redhat-cop/helm-charts.git
     source_path: charts/sonarqube
-    source_ref: "sonarqube-0.0.9"
+    source_ref: "sonarqube-0.0.17"
     sync_policy: *sync_policy_true
     destination: *ci_cd_ns
     values:


### PR DESCRIPTION
Helm charts (argocd, sonarqube, nexus, etherpad) bumped.