### PR TITLE
🍒 ignoreHelmHooks false for initial install, else charts fail 🍒

### DIFF
--- a/argocd-values.yaml
+++ b/argocd-values.yaml
@@ -1,4 +1,4 @@
-ignoreHelmHooks: true
+ignoreHelmHooks: false
 
 #  if using the rh-gitops operator and you want to change the location for the ArgoCD instance to be deployed to:
 # It's defaulted to labs-ci-cd on the chart anyways


### PR DESCRIPTION
from a new cluster,  ignoreHelmHooks must be false as CRD's do not exist.
this matched instructions.

if you want to add the bootstrap to argo at a later time, then set  ignoreHelmHooks to true.