### PR TITLE
🐅 no_helm key is removed 🐅

### DIFF
--- a/templates/argo-application.yaml
+++ b/templates/argo-application.yaml
@@ -34,9 +34,8 @@ spec:
     server: {{ .cluster_api | default "https://kubernetes.default.svc" }}
   project: {{ .project | default "default" }}
   source:
-{{- if not .no_helm }}
+{{- if or .helm_values .values }}
     helm:
-      releaseName: {{ .name }}
 {{- if .helm_values }}
       valueFiles:
 {{- toYaml .helm_values | nindent 8 }}

--- a/ubiquitous-journey/values-tooling.yaml
+++ b/ubiquitous-journey/values-tooling.yaml
@@ -135,7 +135,6 @@ applications:
     source: https://github.com/rht-labs/refactored-adventure
     source_path: crw/base
     source_ref: master
-    no_helm: true
 
   # Allure
 
@@ -201,7 +200,6 @@ applications:
     source: https://github.com/rht-labs/refactored-adventure
     source_path: microcks/base
     source_ref: master
-    no_helm: true
 
   # Pelorus-operators
   - name: pelorus-operators


### PR DESCRIPTION
- Removed `releaseName` key as the default value is already the application CR name and it is recommended to not change https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-release-name

- Removed `no_helm` key as if we have `values` and/or `helm_values` keys, it is enough to have `if` block anyway.
`if not .no_helm `  sounds a bit confusing  😁